### PR TITLE
Fix the gray image checking error

### DIFF
--- a/opencv_transforms/functional.py
+++ b/opencv_transforms/functional.py
@@ -109,7 +109,7 @@ def resize(img, size, interpolation=cv2.INTER_LINEAR):
             output = cv2.resize(img, dsize=(ow, oh), interpolation=interpolation)
     else:
         output = cv2.resize(img, dsize=size[::-1], interpolation=interpolation)
-    if img.shape[2]==1:
+    if img.ndim==2:
         return(output[:,:,np.newaxis])
     else:
         return(output)


### PR DESCRIPTION
The default dimension of a gray image read by opencv is 2, which means using img.shape[2] will raise index error.