### PR TITLE
Only store the int in size if it's an int not a tuple

### DIFF
--- a/opencv_transforms/transforms.py
+++ b/opencv_transforms/transforms.py
@@ -130,10 +130,11 @@ class Resize(object):
         interpolation (int, optional): Desired interpolation. Default is
             ``cv2.INTER_CUBIC``, bicubic interpolation
     """
+
     def __init__(self, size, interpolation=cv2.INTER_LINEAR):
         # assert isinstance(size, int) or (isinstance(size, collections.Iterable) and len(size) == 2)
         if isinstance(size, int):
-            self.size = (size, size)
+            self.size = size
         elif isinstance(size, collections.Iterable) and len(size) == 2:
             if type(size) == list:
                 size = tuple(size)


### PR DESCRIPTION
The documentation for this function is that if you provide an int,
scale will scale the smallest size to the int. Creating a tuple here
ruins the checks in functional. So, just store the int.

(Re-submitting since I was originally in the wrong branch, sorry about that).