### PR TITLE
Add comprehensive tests for RandomApply transform and fix implementation

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -129,7 +129,7 @@ The following transforms lack dedicated unit tests:
 
 ### Random Transforms
 8. **Lambda** (opencv_transforms/transforms.py:273) - No tests for lambda transforms
-9. **RandomApply** (opencv_transforms/transforms.py:312) - No tests for random application
+9. ~~**RandomApply** (opencv_transforms/transforms.py:312) - No tests for random application~~ ✅ **COMPLETED**
 10. **RandomOrder** (opencv_transforms/transforms.py:340) - No tests for random ordering
 11. **RandomChoice** (opencv_transforms/transforms.py:351) - No tests for random choice
 12. **RandomSizedCrop** (opencv_transforms/transforms.py:573) - Deprecated, but no test coverage
@@ -172,7 +172,7 @@ Note: `adjust_gamma` (functional.py:483) has a test but not through the transfor
 6. ~~**TenCrop** - Used in evaluation pipelines~~ ✅ **COMPLETED**
 7. ~~**ColorJitter** (complete) - Important augmentation~~ ✅ **COMPLETED**
 8. **RandomGrayscale** - Common augmentation
-9. **RandomApply** - Useful for conditional augmentation
+9. ~~**RandomApply** - Useful for conditional augmentation~~ ✅ **COMPLETED**
 
 ### Low Priority (Less common/deprecated)
 10. **Lambda** - Edge case usage

--- a/opencv_transforms/transforms.py
+++ b/opencv_transforms/transforms.py
@@ -5,6 +5,8 @@ import random
 import types
 import warnings
 
+import torch
+
 # from PIL import Image, ImageOps, ImageEnhance
 try:
     import accimage
@@ -12,7 +14,6 @@ except ImportError:
     accimage = None
 import cv2
 import numpy as np
-import torch
 
 from . import functional as F
 
@@ -321,7 +322,7 @@ class RandomApply(RandomTransforms):
         self.p = p
 
     def __call__(self, img):
-        if self.p < random.random():
+        if torch.rand(1).item() >= self.p:
             return img
         for t in self.transforms:
             img = t(img)

--- a/tests/test_random_apply.py
+++ b/tests/test_random_apply.py
@@ -1,0 +1,257 @@
+import random
+
+import numpy as np
+import pytest
+import torch
+from torchvision import transforms as T
+
+import opencv_transforms.transforms as cv_transforms
+
+
+class TestRandomApply:
+    @pytest.mark.parametrize("p", [0.0, 0.3, 0.5, 0.7, 1.0])
+    @pytest.mark.parametrize("random_seed", [1, 2, 3, 42, 123])
+    def test_random_apply_single_transform(self, test_images, p, random_seed):
+        """Test RandomApply with single transform matches PyTorch behavior."""
+        pil_images, cv_images = test_images
+
+        # Select random image
+        torch.manual_seed(random_seed)
+        random.seed(random_seed)
+        idx = random.randint(0, len(pil_images) - 1)
+        pil_image = pil_images[idx]
+        cv_image = cv_images[idx].copy()
+
+        # Create transforms with deterministic parameters
+        pil_transform = T.RandomApply([T.ColorJitter(brightness=0.5)], p=p)
+        cv_transform = cv_transforms.RandomApply(
+            [cv_transforms.ColorJitter(brightness=0.5)], p=p
+        )
+
+        # Apply with same random seed
+        torch.manual_seed(random_seed)
+        random.seed(random_seed)
+        pil_result = pil_transform(pil_image)
+
+        torch.manual_seed(random_seed)
+        random.seed(random_seed)
+        cv_result = cv_transform(cv_image)
+
+        # Check if both applied or both didn't apply
+        pil_applied = not np.array_equal(np.array(pil_image), np.array(pil_result))
+        cv_applied = not np.array_equal(cv_image, cv_result)
+
+        assert pil_applied == cv_applied, (
+            f"Application mismatch at p={p}, seed={random_seed}: PyTorch={pil_applied}, OpenCV={cv_applied}"
+        )
+
+        # If both applied, the results should be similar (allowing for precision differences)
+        if pil_applied and cv_applied:
+            pil_array = np.array(pil_result)
+            # Allow generous tolerance for color jitter differences between PIL and OpenCV
+            # ColorJitter can produce significantly different results due to different algorithms
+            assert np.allclose(pil_array, cv_result, rtol=0.3, atol=50), (
+                "Applied transforms should produce reasonably similar results"
+            )
+
+    @pytest.mark.parametrize("p", [0.0, 0.5, 1.0])
+    @pytest.mark.parametrize("random_seed", [1, 2, 3])
+    def test_random_apply_multiple_transforms(self, test_images, p, random_seed):
+        """Test RandomApply with multiple transforms matches PyTorch behavior."""
+        pil_images, cv_images = test_images
+
+        # Select random image
+        torch.manual_seed(random_seed)
+        random.seed(random_seed)
+        idx = random.randint(0, len(pil_images) - 1)
+        pil_image = pil_images[idx]
+        cv_image = cv_images[idx].copy()
+
+        # Create multiple transform pipeline
+        transforms_list = [
+            T.ColorJitter(brightness=0.3),
+            T.RandomHorizontalFlip(p=1.0),  # Always flip for deterministic behavior
+        ]
+        cv_transforms_list = [
+            cv_transforms.ColorJitter(brightness=0.3),
+            cv_transforms.RandomHorizontalFlip(p=1.0),
+        ]
+
+        pil_transform = T.RandomApply(transforms_list, p=p)
+        cv_transform = cv_transforms.RandomApply(cv_transforms_list, p=p)
+
+        # Apply with same random seed
+        torch.manual_seed(random_seed)
+        random.seed(random_seed)
+        pil_result = pil_transform(pil_image)
+
+        torch.manual_seed(random_seed)
+        random.seed(random_seed)
+        cv_result = cv_transform(cv_image)
+
+        # Check if both applied or both didn't apply
+        pil_applied = not np.array_equal(np.array(pil_image), np.array(pil_result))
+        cv_applied = not np.array_equal(cv_image, cv_result)
+
+        assert pil_applied == cv_applied, (
+            f"Application mismatch at p={p}, seed={random_seed}: PyTorch={pil_applied}, OpenCV={cv_applied}"
+        )
+
+    @pytest.mark.parametrize("random_seed", [1, 2, 3])
+    def test_random_apply_probability_zero(self, test_images, random_seed):
+        """Test RandomApply with p=0.0 never applies transforms."""
+        pil_images, cv_images = test_images
+
+        # Select random image
+        torch.manual_seed(random_seed)
+        random.seed(random_seed)
+        idx = random.randint(0, len(pil_images) - 1)
+        pil_image = pil_images[idx]
+        cv_image = cv_images[idx].copy()
+
+        # Create transform that would be very visible if applied
+        pil_transform = T.RandomApply([T.ColorJitter(brightness=2.0)], p=0.0)
+        cv_transform = cv_transforms.RandomApply(
+            [cv_transforms.ColorJitter(brightness=2.0)], p=0.0
+        )
+
+        # Apply multiple times to ensure consistency
+        for _ in range(10):
+            torch.manual_seed(random_seed)
+            random.seed(random_seed)
+            pil_result = pil_transform(pil_image)
+
+            torch.manual_seed(random_seed)
+            random.seed(random_seed)
+            cv_result = cv_transform(cv_image)
+
+            # With p=0.0, results should be identical to input
+            assert np.array_equal(np.array(pil_image), np.array(pil_result)), (
+                "PyTorch should not apply transform with p=0.0"
+            )
+            assert np.array_equal(cv_image, cv_result), (
+                "OpenCV should not apply transform with p=0.0"
+            )
+
+    @pytest.mark.parametrize("random_seed", [1, 2, 3])
+    def test_random_apply_probability_one(self, test_images, random_seed):
+        """Test RandomApply with p=1.0 always applies transforms."""
+        pil_images, cv_images = test_images
+
+        # Select random image
+        torch.manual_seed(random_seed)
+        random.seed(random_seed)
+        idx = random.randint(0, len(pil_images) - 1)
+        pil_image = pil_images[idx]
+        cv_image = cv_images[idx].copy()
+
+        # Create transform that will be visible if applied
+        pil_transform = T.RandomApply([T.ColorJitter(brightness=0.5)], p=1.0)
+        cv_transform = cv_transforms.RandomApply(
+            [cv_transforms.ColorJitter(brightness=0.5)], p=1.0
+        )
+
+        # Apply multiple times to ensure consistency
+        for _ in range(5):
+            torch.manual_seed(random_seed)
+            random.seed(random_seed)
+            pil_result = pil_transform(pil_image)
+
+            torch.manual_seed(random_seed)
+            random.seed(random_seed)
+            cv_result = cv_transform(cv_image)
+
+            # With p=1.0, transforms should always be applied
+            pil_applied = not np.array_equal(np.array(pil_image), np.array(pil_result))
+            cv_applied = not np.array_equal(cv_image, cv_result)
+
+            assert pil_applied, "PyTorch should always apply transform with p=1.0"
+            assert cv_applied, "OpenCV should always apply transform with p=1.0"
+
+    def test_random_apply_empty_transforms(self, test_images):
+        """Test RandomApply with empty transform list."""
+        pil_images, cv_images = test_images
+        pil_image = pil_images[0]
+        cv_image = cv_images[0].copy()
+
+        # Empty transform list should return unchanged image
+        pil_transform = T.RandomApply([], p=0.5)
+        cv_transform = cv_transforms.RandomApply([], p=0.5)
+
+        pil_result = pil_transform(pil_image)
+        cv_result = cv_transform(cv_image)
+
+        assert np.array_equal(np.array(pil_image), np.array(pil_result)), (
+            "PyTorch should return unchanged image for empty transforms"
+        )
+        assert np.array_equal(cv_image, cv_result), (
+            "OpenCV should return unchanged image for empty transforms"
+        )
+
+    @pytest.mark.parametrize("p", [0.2, 0.8])
+    def test_random_apply_with_compose(self, test_images, p):
+        """Test RandomApply works correctly within Compose."""
+        pil_images, cv_images = test_images
+        pil_image = pil_images[0]
+        cv_image = cv_images[0].copy()
+
+        # Create composed transforms
+        pil_compose = T.Compose(
+            [
+                T.RandomApply([T.ColorJitter(brightness=0.3)], p=p),
+                T.ToTensor(),
+            ]
+        )
+        cv_compose = cv_transforms.Compose(
+            [
+                cv_transforms.RandomApply(
+                    [cv_transforms.ColorJitter(brightness=0.3)], p=p
+                ),
+                cv_transforms.ToTensor(),
+            ]
+        )
+
+        # Test multiple times with different seeds
+        for seed in [1, 2, 3]:
+            torch.manual_seed(seed)
+            random.seed(seed)
+            pil_result = pil_compose(pil_image)
+
+            torch.manual_seed(seed)
+            random.seed(seed)
+            cv_result = cv_compose(cv_image)
+
+            # Should produce tensors of same shape and similar values
+            assert pil_result.shape == cv_result.shape, (
+                "Composed transforms should produce same shape"
+            )
+            # Allow for reasonable tolerance due to color jitter differences
+            assert torch.allclose(pil_result, cv_result, rtol=0.1, atol=0.1), (
+                "Composed results should be similar"
+            )
+
+    def test_random_apply_repr(self):
+        """Test RandomApply string representation."""
+        transform = cv_transforms.RandomApply(
+            [
+                cv_transforms.ColorJitter(brightness=0.5),
+                cv_transforms.RandomHorizontalFlip(),
+            ],
+            p=0.3,
+        )
+
+        repr_str = repr(transform)
+        assert "RandomApply" in repr_str
+        assert "p=0.3" in repr_str
+        assert "ColorJitter" in repr_str
+        assert "RandomHorizontalFlip" in repr_str
+
+    @pytest.mark.parametrize("invalid_p", [-0.1, 1.1, 2.0])
+    def test_random_apply_invalid_probability(self, invalid_p):
+        """Test RandomApply handles invalid probability values gracefully."""
+        # This test checks if invalid probabilities are handled
+        # Note: PyTorch doesn't validate p values, so we should match that behavior
+        transform = cv_transforms.RandomApply(
+            [cv_transforms.ColorJitter()], p=invalid_p
+        )
+        assert transform.p == invalid_p  # Should store the value as-is


### PR DESCRIPTION
## Summary
- Fixed RandomApply implementation to match PyTorch's behavior exactly
- Added comprehensive test suite with 47 test cases
- Updated TEST_PLAN.md to mark RandomApply as completed

## Key Changes

### Implementation Fix
- Changed from `random.random()` to `torch.rand()` for PyTorch compatibility
- Fixed logic from `p < random()` to `random() >= p` to match PyTorch's RandomApply behavior
- Added proper `torch` import to transforms.py

### Comprehensive Test Coverage
- **47 test cases** covering all scenarios:
  - Single and multiple transform application
  - Various probability values (0.0, 0.3, 0.5, 0.7, 1.0)
  - Multiple random seeds for deterministic testing (1, 2, 3, 42, 123)
  - Edge cases (p=0.0 never applies, p=1.0 always applies)  
  - Empty transform lists
  - Integration with Compose
  - String representation testing
  - Invalid probability handling

### Behavior Verification
- Verified RandomApply now produces identical random decisions as PyTorch with same seeds
- Tests ensure both implementations apply or skip transforms consistently
- Allows reasonable tolerance for ColorJitter differences between PIL and OpenCV algorithms

## Test Results
All 47 tests pass, confirming RandomApply now matches PyTorch behavior perfectly.

## Files Changed
- `opencv_transforms/transforms.py` - Fixed RandomApply implementation
- `tests/test_random_apply.py` - New comprehensive test suite  
- `TEST_PLAN.md` - Updated to mark RandomApply as completed

🤖 Generated with [Claude Code](https://claude.ai/code)